### PR TITLE
More compact navbar on mobile

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,9 +7,11 @@
 
     {% if site.data.navigation %}
     <nav class="navbar navbar-light navbar-expand-lg" id="navbar">
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
+        <div class="navbar-toggler-container">
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+        </div>
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
             <ul class="navbar-nav me-auto mb-2 mb-lg-0">
                 {% for item in site.data.navigation %}

--- a/_sass/overrides.scss
+++ b/_sass/overrides.scss
@@ -26,6 +26,37 @@
 #navbar {
     padding: 0;
     font-weight: bold;
+    display: block;
+    float: right;
+    margin-top: .5rem;
+    max-height: 0;
+
+    @media only screen and (min-width: 991px) {
+        display: initial;
+        float: none;
+        margin: auto;
+    }
+
+    .navbar-collapse.collapse.show {
+        padding: 0px 0.5em;
+        border: 1px solid var(--border-color);
+        border-radius: var(--border-radius);
+        margin-top: 0.5em;
+        background-color: var(--body-bg-color);
+
+        @media only screen and (min-width: 991px) {
+            margin: auto;
+            border: 0;
+        }
+    }
+
+    .navbar-collapse.collapsing {
+        @extend .navbar-collapse.collapse.show;
+    }
+
+    .navbar-toggler-container {
+        text-align: right;
+    }
 }
 
 .post-link:hover {
@@ -48,6 +79,14 @@
 
 .masthead {
     margin-bottom: var(--spacer);
+}
+
+.masthead-title {
+    display: inline-block;
+
+    @media only screen and (min-width: 991px) {
+        display: initial;
+    }
 }
 
 #home-carousel {


### PR DESCRIPTION
I've put the collapsible navbar menu onto the same line as `masthead-title` and given the menu a border and background when expanded.

![Screenshot from 2021-10-13 15-11-34](https://user-images.githubusercontent.com/25610245/137150444-07e2f548-0d43-4461-adf5-f20bf7a771d8.png)