### PR TITLE
Update social.yml

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -5,5 +5,5 @@
   url: https://twitter.com/photosocuob
   icon: fab fa-twitter
 - title: Instagram
-  url: https://github.com/zivhub
+  url: https://instagram.com/photosocuob
   icon: fab fa-instagram


### PR DESCRIPTION
Instagram logo now goes to PhotoSoc's Instagram.