### PR TITLE
Fix deprecation warning

### DIFF
--- a/_sass/overrides.scss
+++ b/_sass/overrides.scss
@@ -51,7 +51,7 @@
     }
 
     .navbar-collapse.collapsing {
-        @extend .navbar-collapse.collapse.show;
+        @extend .navbar-collapse, .collapse, .show;
     }
 
     .navbar-toggler-container {


### PR DESCRIPTION
The "extending compound selector" deprecation warning is [explained here](https://sass-lang.com/documentation/breaking-changes/extend-compound).
Just to make sure I tested the following code snippet on [this online Sass editor](https://www.sassmeister.com/) with an older compiler selected (Ruby Sass v3.7.4), compared the generated CSS files and they were identical.

```sass
.navbar-collapse.collapse.show {
    padding: 0px 0.5em;
    border: 1px solid var(--border-color);
    border-radius: var(--border-radius);
    margin-top: 0.5em;
    background-color: var(--body-bg-color);

    @media only screen and (min-width: 991px) {
        margin: auto;
        border: 0;
    }
}

.navbar-collapse.collapsing {
    @extend .navbar-collapse.collapse.show;
}
```
